### PR TITLE
Set least privilege permissions for GitHub Workflow tokens

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,8 @@ name: Running Code Coverage
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   build:
 

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,6 +4,21 @@ on:
   pull_request:
     types: [opened, reopened]
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  id-token: write
+  issues: write
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   issue:
       runs-on: ubuntu-latest

--- a/.github/workflows/issuehunt.yml
+++ b/.github/workflows/issuehunt.yml
@@ -2,6 +2,22 @@ name: Auto message for Issues
 on:
   issues:
     types: [opened, reopened]
+
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  id-token: write
+  issues: write
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   comment:
     name: Hello new contributor


### PR DESCRIPTION
Closes https://github.com/goatandsheep/rc/issues/29

As described in the issue, this PR sets minimum permissions for GITHUB_TOKEN in GitHub Workflows.

For the coverage workflow, we are setting all permissions to `read` because the job steps need no permissions.
For the dependabot workflow, we are setting `id-token` to have `write` access because we need to get the GITHUB_TOKEN and `issues` to have `write` access because we need to create an issue.
For the issue hunt workflow, we are setting `id-token` to have `write` access because we need to get the GITHUB_TOKEN and `issues` to have `write` access because we need to create a comment on an issue.